### PR TITLE
Upgrade Elasticsearch dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }
 
-val elasticsearchVersion = "7.10.2"
+val elasticsearchVersion = "7.13.0"
 val kotlinVersion = "1.4.20"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,14 +42,14 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"))
 
     // Use the Kotlin JDK 8 standard library.
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     // Use the Kotlin test library.
-    testImplementation("org.jetbrains.kotlin:kotlin-test:$kotlinVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
 
     // Use the Kotlin JUnit integration.
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
 }
 
 tasks.withType<KotlinCompile> {


### PR DESCRIPTION
- Update Elasticsearch to the latest version `7.13.0`. This also patches the vulnerability [CVE-2021-22134](https://ossindex.sonatype.org/vuln/47abd647-6921-413f-8fd8-46e5005563f1).

Also removed the explicit version from dependencies in the group `org.jetbrains.kotlin` since they are covered from the `kotlin-bom`.

When a new release of the plugin is cut I can update https://github.com/jillesvangurp/es-kotlin-client